### PR TITLE
Remove `to` parameter when publishing contract transaction

### DIFF
--- a/src/Contract.php
+++ b/src/Contract.php
@@ -397,7 +397,6 @@ class Contract
             if (count($arguments) > 0) {
                 $transaction = $arguments[0];
             }
-            $transaction['to'] = '';
             $transaction['data'] = '0x' . $this->bytecode . Utils::stripZero($data);
 
             $this->eth->sendTransaction($transaction, function ($err, $transaction) use ($callback){


### PR DESCRIPTION
If sending empty `to` parameter, the error `Invalid params: expected a hex-encoded hash with 0x prefix.` is raised by Parity node.