### PR TITLE
Replace Utils::toHex() with direct conversion.

### DIFF
--- a/src/Contracts/Types/Str.php
+++ b/src/Contracts/Types/Str.php
@@ -59,7 +59,7 @@ class Str extends SolidityType implements IType
      */
     public function inputFormat($value, $name)
     {
-        $value = Utils::toHex($value);
+        $value = implode('', unpack('H*', $value));
         $prefix = IntegerFormatter::format(mb_strlen($value) / 2);
         $l = floor((mb_strlen($value) + 63) / 64);
         $padding = (($l * 64 - mb_strlen($value) + 1) >= 0) ? $l * 64 - mb_strlen($value) : 0;


### PR DESCRIPTION
If an argument to a contract method is a string which can be converted to number (like "1"), `Utils::toHex()` does this conversion. Also if sting starts with '0x' it will be stripped, which may be not expected behaviour.