### PR TITLE
Fixing HexValidator

### DIFF
--- a/src/Validators/HexValidator.php
+++ b/src/Validators/HexValidator.php
@@ -23,9 +23,6 @@ class HexValidator
      */
     public static function validate($value)
     {
-        if (!is_string($value)) {
-            return false;
-        }
-        return (preg_match('/^0x[a-fA-F0-9]*$/', $value) >= 1);
+        return is_string($value) && ctype_xdigit($value);
     }
 }


### PR DESCRIPTION
> Fatal error: Uncaught InvalidArgumentException: Please make sure bytecode is valid.

I was getting the above error while trying to deploy a contract. Even though the bytecode is valid, it was failing the test!

I fixed the  **HexValidator** code to use `ctype_xdigit` instead of regular expression test

Here is the **bytecode** I was using

`608060405234801561001057600080fd5b50336000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff160217905550610153806100606000396000f300608060405260043610610041576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680638da5cb5b146100ab575b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166108fc349081150290604051600060405180830381858888f193505050501580156100a8573d6000803e3d6000fd5b50005b3480156100b757600080fd5b506100c0610102565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff16815600a165627a7a72305820b046fb6375f52001c172f53c2c857e90d3a714f3dd6ca4e85e1043ff42cd16c40029`

**abi**
```json
[
	{
		"constant": true,
		"inputs": [],
		"name": "owner",
		"outputs": [
			{
				"name": "",
				"type": "address"
			}
		],
		"payable": false,
		"stateMutability": "view",
		"type": "function"
	},
	{
		"inputs": [],
		"payable": false,
		"stateMutability": "nonpayable",
		"type": "constructor"
	},
	{
		"payable": true,
		"stateMutability": "payable",
		"type": "fallback"
	}
]
```

**Source code**
```sol
pragma solidity ^0.4.19;

contract Forwarder {
    address public owner;

    function Forwarder() public {
        owner = msg.sender;
    }

    function() external payable {
        owner.transfer(msg.value);
    }
}
```