### PR TITLE
Fix: method validation in both send and call

### DIFF
--- a/src/Contract.php
+++ b/src/Contract.php
@@ -422,8 +422,8 @@ class Contract
             $method = array_splice($arguments, 0, 1)[0];
             $callback = array_pop($arguments);
 
-            if (!is_string($method) && !isset($this->functions[$method])) {
-                throw new InvalidArgumentException('Please make sure the method is existed.');
+            if (!is_string($method) || !isset($this->functions[$method])) {
+                throw new InvalidArgumentException('Please make sure the method exists.');
             }
             $function = $this->functions[$method];
 
@@ -468,8 +468,8 @@ class Contract
             $method = array_splice($arguments, 0, 1)[0];
             $callback = array_pop($arguments);
 
-            if (!is_string($method) && !isset($this->functions[$method])) {
-                throw new InvalidArgumentException('Please make sure the method is existed.');
+            if (!is_string($method) || !isset($this->functions[$method])) {
+                throw new InvalidArgumentException('Please make sure the method exists.');
             }
             $function = $this->functions[$method];
 


### PR DESCRIPTION
Making sure method is a string and it exists under functions

I was trying to call a nonexistent method. Since I passed a string it went through without checking if it exists as a function or not

This commit fixes that by changing `&&` to `||` (or)