### PR TITLE
There is an issue with this check now because the "?" Symbol was remo…

### DIFF
--- a/src/Contracts/Types/Bytes.php
+++ b/src/Contracts/Types/Bytes.php
@@ -36,7 +36,7 @@ class Bytes extends SolidityType implements IType
      */
     public function isType($name)
     {
-        return (preg_match('/^bytes([0-9]{1,})(\[([0-9]*)\])*$/', $name) === 1);
+        return (preg_match('/^bytes([0-9]{1,})?(\[([0-9]*)\])*$/', $name) === 1);
     }
 
     /**


### PR DESCRIPTION
There is an issue with this check now because the "?" Symbol was removed, as a result of this preg_match does not match for 'bytes'.

The error: "unsupport solidity parameter type: bytes" is thrown.

The correct version should be:
"return (preg_match('/^bytes([0-9]{1,})?([([0-9])])$/', $name) === 1);"