### PR TITLE
Don't send an empty "to" address when estimating gas for the constructor

### DIFF
--- a/src/Contract.php
+++ b/src/Contract.php
@@ -544,7 +544,6 @@ class Contract
                 if (count($arguments) > 0) {
                     $transaction = $arguments[0];
                 }
-                $transaction['to'] = '';
                 $transaction['data'] = '0x' . $this->bytecode . Utils::stripZero($data);
             } else {
                 $method = array_splice($arguments, 0, 1)[0];


### PR DESCRIPTION
Sending a empty "to" address when estimating the gas usage of the contract constructor returns the following error (from geth at least):

> invalid argument 0: hex string has length 0, want 40 for common.Address in