### PR TITLE
Fix toHex: is numbericPHP Fatal error:  Uncaught Error: Call to a mem…

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -90,7 +90,7 @@ class Utils
         if (is_string($value)) {
             $value = self::stripZero($value);
             $hex = implode('', unpack('H*', $value));
-        } esleif (is_numeric($value)) {
+        } elseif (is_numeric($value)) {
             // turn to hex number
             $bn = self::toBn($value);
             $hex = $bn->toHex(true);

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -87,14 +87,14 @@ class Utils
      */
     public static function toHex($value, $isPrefix=false)
     {
-        if (is_numeric($value)) {
+        if (is_string($value)) {
+            $value = self::stripZero($value);
+            $hex = implode('', unpack('H*', $value));
+        } esleif (is_numeric($value)) {
             // turn to hex number
             $bn = self::toBn($value);
             $hex = $bn->toHex(true);
             $hex = preg_replace('/^0+(?!$)/', '', $hex);
-        } elseif (is_string($value)) {
-            $value = self::stripZero($value);
-            $hex = implode('', unpack('H*', $value));
         } elseif ($value instanceof BigNumber) {
             $hex = $value->toHex(true);
             $hex = preg_replace('/^0+(?!$)/', '', $hex);


### PR DESCRIPTION
Fix Bug
toHex: is numbericPHP Fatal error:  Uncaught Error: Call to a member function toHex() on array in \web3.php\src\Formatters\IntegerFormatter.php:36


move is_string() to the front of is_numeric(), resolve the problem of digit string recognition. such as a string "20180001"