### PR TITLE
add: defaultBlock in Contract.call() method

### DIFF
--- a/src/Contract.php
+++ b/src/Contract.php
@@ -109,7 +109,7 @@ class Contract
      * @param string|\stdClass|array $abi
      * @return void
      */
-    public function __construct($provider, $abi, $defaultBlock = 'pending')
+    public function __construct($provider, $abi, $defaultBlock = 'latest')
     {
         if (is_string($provider) && (filter_var($provider, FILTER_VALIDATE_URL) !== false)) {
             // check the uri schema


### PR DESCRIPTION
Add a protected property `$defaultBlock` in Contract.__construct()

from the rpc document [eth.call](https://github.com/ethereum/wiki/wiki/JavaScript-API#web3ethcall) can send defaultBlock but I can't find out how to use contract's call in pending block with current code.