### PR TITLE
Removed space from versions of guzzlehttp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "^6.3 | ^7.0",
+        "guzzlehttp/guzzle": "^6.3|^7.0",
         "PHP": "^7.1",
         "kornrunner/keccak": "~1.0",
         "phpseclib/phpseclib": "~2.0.11",


### PR DESCRIPTION
Removed space from versions of guzzlehttp, else second version was not working in laravel