### PR TITLE
If parameters are sent as an array. To avoid problems.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "^6.3|^7.0",
+        "guzzlehttp/guzzle": "^7.0",
         "PHP": "^7.1",
         "kornrunner/keccak": "~1.0",
         "phpseclib/phpseclib": "~2.0.11",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "sc0vu/web3.php",
+    "name": "beycan/web3.php",
     "description": "Ethereum web3 interface.",
     "type": "library",
     "license": "MIT",

--- a/src/Contract.php
+++ b/src/Contract.php
@@ -587,6 +587,8 @@ class Contract
             $method = array_splice($arguments, 0, 1)[0];
             $callback = array_pop($arguments);
 
+            $arguments = is_array($arguments[0]) ? $arguments[0] : $arguments;
+            
             if (!is_string($method)) {
                 throw new InvalidArgumentException('Please make sure the method is string.');
             }


### PR DESCRIPTION
In my own package, I prepared a method in the Token class as follows, and there was a problem because it sent the parameters as an array. I made a small change to prevent the problem in such uses.

```
/**
   * @param string $name
   * @param array $args
   * @return mixed
   */
  public function __call(string $name, array $args)
  {
      $result = null;
      $this->contract->call($name, $args, function($err, $res) use (&$result) {
          if ($err) {
              throw new \Exception($err->getMessage(), $err->getCode());
          } else {
              $result = $res;
          }
      });

      return $result;
  }
```