### PR TITLE
Support PHP 8.0

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -7,7 +7,7 @@ jobs:
     name: Build and test web3.php with ${{ matrix.php-version }}
     strategy:
       matrix:
-        php-version: ["7.3", "7.4"]
+        php-version: ["7.3", "7.4", "8.0"]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,6 +1,6 @@
 name: PHP
 
-on: ["push", "pull_request"]
+on: ["push", "pull_request", "workflow_dispatch"]
 
 jobs:
   build_and_test:

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
     ],
     "require": {
         "guzzlehttp/guzzle": "^6.3|^7.0",
-        "PHP": "^7.1",
+        "PHP": "^7.1|^8.0",
         "kornrunner/keccak": "~1.0",
         "phpseclib/phpseclib": "~2.0.11",
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.0"
+        "phpunit/phpunit": "~6.0|~8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
     ],
     "require": {
         "guzzlehttp/guzzle": "^6.3|^7.0",
-        "PHP": "^7.1|^8.0",
+        "PHP": "^7.2|^8.0",
         "kornrunner/keccak": "~1.0",
-        "phpseclib/phpseclib": "~2.0.11",
+        "phpseclib/phpseclib": "~2.0.30",
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.0|~8.0"
+        "phpunit/phpunit": "~8.0|~9.0"
     },
     "autoload": {
         "psr-4": {

--- a/docker/php/Dockerfile-80
+++ b/docker/php/Dockerfile-80
@@ -1,0 +1,23 @@
+FROM php:8.0-alpine
+
+MAINTAINER Peter Lai <alk03073135@gmail.com>
+
+COPY composer-setup.php composer-setup.php
+# COPY php.ini-production $PHP_INI_DIR/php.ini
+
+RUN apk update && \
+    apk add git
+
+# Install gmp
+Run apk add gmp-dev && \
+    docker-php-ext-install gmp
+
+# Install nodejs
+# Run apk add --update nodejs nodejs-npm
+
+# Install composer
+RUN php composer-setup.php && \
+    php composer-setup.php --install-dir=/usr/bin --filename=composer && \
+    php -r "unlink('composer-setup.php');"
+
+WORKDIR /app

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,8 +7,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
 
     <testsuite name="Web3.php unit test">
         <directory suffix="Test.php">./test/unit</directory>

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -529,7 +529,7 @@ class Utils
                 $number = str_replace('-', '', $number, $count);
                 $negative1 = new BigNumber(-1);
             }
-            if (self::isZeroPrefixed($number) || preg_match('/[a-f]+/', $number) === 1) {
+            if (self::isZeroPrefixed($number) || preg_match('/^[0-9a-f]+$/i', $number) === 1) {
                 $number = self::stripZero($number);
                 $bn = new BigNumber($number, 16);
             } elseif (empty($number)) {

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -37,10 +37,8 @@ class TestCase extends BaseTestCase
 
     /**
      * setUp
-     * 
-     * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $web3 = new Web3($this->testHost);
         $this->web3 = $web3;
@@ -55,8 +53,6 @@ class TestCase extends BaseTestCase
 
     /**
      * tearDown
-     * 
-     * @return void
      */
-    public function tearDown() {}
+    public function tearDown(): void {}
 }

--- a/test/unit/AddressFormatterTest.php
+++ b/test/unit/AddressFormatterTest.php
@@ -19,7 +19,7 @@ class AddressFormatterTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->formatter = new AddressFormatter;

--- a/test/unit/AddressTypeTest.php
+++ b/test/unit/AddressTypeTest.php
@@ -47,7 +47,7 @@ class AddressTypeTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->solidityType = new Address;

--- a/test/unit/AddressValidatorTest.php
+++ b/test/unit/AddressValidatorTest.php
@@ -19,7 +19,7 @@ class AddressValidatorTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->validator = new AddressValidator;

--- a/test/unit/BigNumberFormatterTest.php
+++ b/test/unit/BigNumberFormatterTest.php
@@ -20,7 +20,7 @@ class BigNumberFormatterTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->formatter = new BigNumberFormatter;

--- a/test/unit/BlockHashValidatorTest.php
+++ b/test/unit/BlockHashValidatorTest.php
@@ -19,7 +19,7 @@ class BlockHashValidatorTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->validator = new BlockHashValidator;

--- a/test/unit/BooleanFormatterTest.php
+++ b/test/unit/BooleanFormatterTest.php
@@ -20,7 +20,7 @@ class BooleanFormatterTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->formatter = new BooleanFormatter;

--- a/test/unit/BooleanTypeTest.php
+++ b/test/unit/BooleanTypeTest.php
@@ -47,7 +47,7 @@ class BooleanTypeTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->solidityType = new Boolean;

--- a/test/unit/BooleanValidatorTest.php
+++ b/test/unit/BooleanValidatorTest.php
@@ -19,7 +19,7 @@ class BooleanValidatorTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->validator = new BooleanValidator;

--- a/test/unit/BytesTypeTest.php
+++ b/test/unit/BytesTypeTest.php
@@ -53,7 +53,7 @@ class BytesTypeTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->solidityType = new Bytes;

--- a/test/unit/CallValidatorTest.php
+++ b/test/unit/CallValidatorTest.php
@@ -19,7 +19,7 @@ class CallValidatorTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->validator = new CallValidator;

--- a/test/unit/ContractTest.php
+++ b/test/unit/ContractTest.php
@@ -412,7 +412,7 @@ class ContractTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/test/unit/DynamicBytesTypeTest.php
+++ b/test/unit/DynamicBytesTypeTest.php
@@ -53,7 +53,7 @@ class DynamicBytesTypeTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->solidityType = new DynamicBytes;

--- a/test/unit/EthApiTest.php
+++ b/test/unit/EthApiTest.php
@@ -21,7 +21,7 @@ class EthApiTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/test/unit/EthBatchTest.php
+++ b/test/unit/EthBatchTest.php
@@ -20,7 +20,7 @@ class EthBatchTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/test/unit/EthTest.php
+++ b/test/unit/EthTest.php
@@ -23,7 +23,7 @@ class EthTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/test/unit/EthabiTest.php
+++ b/test/unit/EthabiTest.php
@@ -163,7 +163,7 @@ class EthabiTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         // Error: Using $this when not in object context

--- a/test/unit/FilterValidatorTest.php
+++ b/test/unit/FilterValidatorTest.php
@@ -19,7 +19,7 @@ class FilterValidatorTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->validator = new FilterValidator;

--- a/test/unit/HexFormatterTest.php
+++ b/test/unit/HexFormatterTest.php
@@ -19,7 +19,7 @@ class HexFormatterTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->formatter = new HexFormatter;

--- a/test/unit/HexValidatorTest.php
+++ b/test/unit/HexValidatorTest.php
@@ -19,7 +19,7 @@ class HexValidatorTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->validator = new HexValidator;

--- a/test/unit/IdentityValidatorTest.php
+++ b/test/unit/IdentityValidatorTest.php
@@ -19,7 +19,7 @@ class IdentityValidatorTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->validator = new IdentityValidator;

--- a/test/unit/IntegerFormatterTest.php
+++ b/test/unit/IntegerFormatterTest.php
@@ -19,7 +19,7 @@ class IntegerFormatterTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->formatter = new IntegerFormatter;

--- a/test/unit/IntegerTypeTest.php
+++ b/test/unit/IntegerTypeTest.php
@@ -53,7 +53,7 @@ class IntegerTypeTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->solidityType = new Integer;

--- a/test/unit/NetApiTest.php
+++ b/test/unit/NetApiTest.php
@@ -21,7 +21,7 @@ class NetApiTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/test/unit/NetBatchTest.php
+++ b/test/unit/NetBatchTest.php
@@ -20,7 +20,7 @@ class NetBatchTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/test/unit/NetTest.php
+++ b/test/unit/NetTest.php
@@ -23,7 +23,7 @@ class NetTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/test/unit/NonceValidatorTest.php
+++ b/test/unit/NonceValidatorTest.php
@@ -19,7 +19,7 @@ class NonceValidatorTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->validator = new NonceValidator;

--- a/test/unit/NumberFormatterTest.php
+++ b/test/unit/NumberFormatterTest.php
@@ -19,7 +19,7 @@ class NumberFormatterTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->formatter = new NumberFormatter;

--- a/test/unit/OptionalQuantityFormatterTest.php
+++ b/test/unit/OptionalQuantityFormatterTest.php
@@ -19,7 +19,7 @@ class OptionalQuantityFormatterTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->formatter = new OptionalQuantityFormatter;

--- a/test/unit/OptionalQuantityFormatterTest.php
+++ b/test/unit/OptionalQuantityFormatterTest.php
@@ -55,6 +55,8 @@ class OptionalQuantityFormatterTest extends TestCase
         $this->assertEquals('latest', $formatter->format('latest'));
         $this->assertEquals('earliest', $formatter->format('earliest'));
         $this->assertEquals('pending', $formatter->format('pending'));
-        $this->assertEquals('0x0', $formatter->format('hello'));
+
+        $this->expectExceptionMessage('toBn number must be valid hex string.');
+        $formatter->format('hello');
     }
 }

--- a/test/unit/PersonalApiTest.php
+++ b/test/unit/PersonalApiTest.php
@@ -27,7 +27,7 @@ class PersonalApiTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/test/unit/PersonalBatchTest.php
+++ b/test/unit/PersonalBatchTest.php
@@ -19,7 +19,7 @@ class PersonalBatchTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/test/unit/PersonalTest.php
+++ b/test/unit/PersonalTest.php
@@ -23,7 +23,7 @@ class PersonalTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/test/unit/PostFormatterTest.php
+++ b/test/unit/PostFormatterTest.php
@@ -19,7 +19,7 @@ class PostFormatterTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->formatter = new PostFormatter;

--- a/test/unit/PostValidatorTest.php
+++ b/test/unit/PostValidatorTest.php
@@ -19,7 +19,7 @@ class PostValidatorTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->validator = new PostValidator;

--- a/test/unit/QuantityFormatterTest.php
+++ b/test/unit/QuantityFormatterTest.php
@@ -19,7 +19,7 @@ class QuantityFormatterTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->formatter = new QuantityFormatter;

--- a/test/unit/QuantityValidatorTest.php
+++ b/test/unit/QuantityValidatorTest.php
@@ -19,7 +19,7 @@ class QuantityValidatorTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->validator = new QuantityValidator;

--- a/test/unit/ShhApiTest.php
+++ b/test/unit/ShhApiTest.php
@@ -21,7 +21,7 @@ class ShhApiTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/test/unit/ShhBatchTest.php
+++ b/test/unit/ShhBatchTest.php
@@ -19,7 +19,7 @@ class ShhBatchTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/test/unit/ShhFilterValidatorTest.php
+++ b/test/unit/ShhFilterValidatorTest.php
@@ -19,7 +19,7 @@ class ShhFilterValidatorTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->validator = new ShhFilterValidator;

--- a/test/unit/ShhTest.php
+++ b/test/unit/ShhTest.php
@@ -23,7 +23,7 @@ class ShhTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/test/unit/SolidityTypeTest.php
+++ b/test/unit/SolidityTypeTest.php
@@ -20,7 +20,7 @@ class SolidityTypeTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->type = new SolidityType();

--- a/test/unit/StrTypeTest.php
+++ b/test/unit/StrTypeTest.php
@@ -47,7 +47,7 @@ class StrTypeTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->solidityType = new Str;

--- a/test/unit/StringFormatterTest.php
+++ b/test/unit/StringFormatterTest.php
@@ -19,7 +19,7 @@ class StringFormatterTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->formatter = new StringFormatter;

--- a/test/unit/StringValidatorTest.php
+++ b/test/unit/StringValidatorTest.php
@@ -19,7 +19,7 @@ class StringValidatorTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->validator = new StringValidator;

--- a/test/unit/TagValidatorTest.php
+++ b/test/unit/TagValidatorTest.php
@@ -19,7 +19,7 @@ class TagValidatorTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->validator = new TagValidator;

--- a/test/unit/TransactionFormatterTest.php
+++ b/test/unit/TransactionFormatterTest.php
@@ -19,7 +19,7 @@ class TransactionFormatterTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->formatter = new TransactionFormatter;

--- a/test/unit/TransactionValidatorTest.php
+++ b/test/unit/TransactionValidatorTest.php
@@ -19,7 +19,7 @@ class TransactionValidatorTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->validator = new TransactionValidator;

--- a/test/unit/UintegerTypeTest.php
+++ b/test/unit/UintegerTypeTest.php
@@ -53,7 +53,7 @@ class UintegerTypeTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->solidityType = new Uinteger;

--- a/test/unit/UtilsTest.php
+++ b/test/unit/UtilsTest.php
@@ -137,7 +137,7 @@ class UtilsTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
     }

--- a/test/unit/Web3ApiTest.php
+++ b/test/unit/Web3ApiTest.php
@@ -29,7 +29,7 @@ class Web3ApiTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
     }

--- a/test/unit/Web3BatchTest.php
+++ b/test/unit/Web3BatchTest.php
@@ -28,7 +28,7 @@ class Web3BatchTest extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
     }

--- a/test/unit/Web3Test.php
+++ b/test/unit/Web3Test.php
@@ -37,7 +37,7 @@ class Web3Test extends TestCase
      * 
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
     }


### PR DESCRIPTION
This pull request add support for PHP 8.0 and bumps minimum version for package to 7.2 (instead of 7.1).

- Bumps PHPUnit to ~8.0|~9.0.
- Update all tests to be compatible with the new PHPUnit version.
- Fix preg_match expression to detect hexadecimal strings correctly ([src/Utils.php](https://github.com/web3p/web3.php/compare/master...cryptounifier:php-80-test-passing?expand=1#diff-29604b8d3d680574d348a450de44692476847958c077b350b4dd553c4864f07d)).
- Update the test to the expected behavior, that its thrown an exception instead of returning 0x0. ([test/unit/OptionalQuantityFormatterTest.php](https://github.com/web3p/web3.php/compare/master...cryptounifier:php-80-test-passing?expand=1#diff-e6e3ec5e1465df25569627646ff831bf105d6100a3e6592efcdb211888166a85)).

The wrong preg_match with this test that broke the tests to PHP 8.0. The phpseclib returns empty when sending an invalid hexadecimal string using PHP 7 (making the old test pass),  but for PHP 8 it throws an exception (since the correct behavior is to send only hexadecimal strings).