### PR TITLE
Fix HEX encoding for very large numbers - issue #268

### DIFF
--- a/src/Formatters/IntegerFormatter.php
+++ b/src/Formatters/IntegerFormatter.php
@@ -33,7 +33,7 @@ class IntegerFormatter implements IFormatter
             $digit = intval($arguments[1]);
         }
         $bn = Utils::toBn($value);
-        $bnHex = $bn->toHex(true);
+        $bnHex = $bn->toHex(Utils::isNegative($value));
         $padded = mb_substr($bnHex, 0, 1);
 
         if ($padded !== 'f') {


### PR DESCRIPTION
Very large non-negative numbers are encoded to hex strings in excess of 64 chars - this is due to Two's Complement representation being set to true on these non-negative numbers.

This minor edit ensures that Two's Complement representation on hex conversion is only applied when the number is actually negative.