### PR TITLE
Updated Utils and BigNumberFormatter to handle hex edge cases

### DIFF
--- a/src/Contracts/Types/Uinteger.php
+++ b/src/Contracts/Types/Uinteger.php
@@ -73,7 +73,7 @@ class Uinteger extends SolidityType implements IType
     {
         $match = [];
 
-        if (preg_match('/^[0]+([a-f0-9]+)$/', $value, $match) === 1) {
+        if (preg_match('/^([a-f0-9]+)$/', $value, $match) === 1) {
             // due to value without 0x prefix, we will parse as decimal
             $value = '0x' . $match[1];
         }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -492,7 +492,7 @@ class Utils
             $bn = $number;
         } elseif (is_int($number)) {
             $bn = new BigNumber($number);
-        } elseif (is_numeric($number)) {
+        } elseif (preg_match('/^(-{0,1})[0-9]*$/', $number)) {
             $number = (string) $number;
 
             if (self::isNegative($number)) {


### PR DESCRIPTION
The current web3.php was mysteriously returning numbers like this: `70706864786e6862` instead of the full hex from numbers like `70706864786e6862000000000000000000000000000000000000000000000026`. It happens only in the edge case where the hex has a single 'e' in it. These changes fix that scenario.

If you're wondering how we found this out, we ran into an edge case with `tokenIds` in our [NFT Smart Contract](https://community.intercoin.org/t/intercoins-nft-smart-contract-released-audited) when we started generating token IDs of the form `seriesId + autoIndex`. It just so happened that our `seriesId` had a single `e` in it. And PHP's `is_numeric` [interprets](https://www.php.net/manual/en/function.is-numeric.php) numbers of the form '123e456' to be decimal representations of large numbers!