### PR TITLE
Resolve problem with mb_substr() on Laravel 9/10 and PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,11 @@
 {
-    "name": "web3p/web3.php",
+    "name": "ca-morfeusz2844/web3.php",
     "description": "Ethereum web3 interface.",
     "type": "library",
     "license": "MIT",
     "authors": [
         {
-            "name": "sc0Vu",
-            "email": "alk03073135@gmail.com"
+            "name": "ca-morfeusz2844"
         }
     ],
     "require": {

--- a/src/Contracts/SolidityType.php
+++ b/src/Contracts/SolidityType.php
@@ -262,7 +262,7 @@ class SolidityType
             $dynamicOffset = (int) Utils::toBn('0x' . mb_substr($value, $offset * 2, 64))->toString();
             $length = (int) Utils::toBn('0x' . mb_substr($value, $dynamicOffset * 2, 64))->toString();
             $roundedLength = floor(($length + 31) / 32);
-            $param = mb_substr($value, $dynamicOffset * 2, ( 1 + $roundedLength) * 64);
+            $param = mb_substr($value, $dynamicOffset * 2, (int)(( 1 + $roundedLength) * 64));
             return $this->outputFormat($param, $name);
         }
         $length = $this->staticPartLength($name);


### PR DESCRIPTION
mb_substr(): Argument #3 ($length) must be of type ?int, float given