### PR TITLE
Make the code compatible with phpseclib 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "guzzlehttp/guzzle": "^6.3|^7.0",
         "PHP": "^7.2|^8.0",
         "kornrunner/keccak": "~1.0",
-        "phpseclib/phpseclib": "~2.0.30",
+        "phpseclib/phpseclib": "^3.0.36",
         "ext-mbstring": "*",
         "react/http": "^1.6.0",
         "react/async": "^4.0.0|^3.1.0",

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -2,9 +2,9 @@
 
 /**
  * This file is part of web3.php package.
- * 
+ *
  * (c) Kuan-Cheng,Lai <alk03073135@gmail.com>
- * 
+ *
  * @author Peter Lai <alk03073135@gmail.com>
  * @license MIT
  */
@@ -15,13 +15,13 @@ use RuntimeException;
 use InvalidArgumentException;
 use stdClass;
 use kornrunner\Keccak;
-use phpseclib\Math\BigInteger as BigNumber;
+use phpseclib3\Math\BigInteger as BigNumber;
 
 class Utils
 {
     /**
      * SHA3_NULL_HASH
-     * 
+     *
      * @const string
      */
     const SHA3_NULL_HASH = 'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470';
@@ -29,7 +29,7 @@ class Utils
     /**
      * UNITS
      * from ethjs-unit
-     * 
+     *
      * @const array
      */
     const UNITS = [
@@ -65,7 +65,7 @@ class Utils
     /**
      * NEGATIVE1
      * Cannot work, see: http://php.net/manual/en/language.constants.syntax.php
-     * 
+     *
      * @const
      */
     // const NEGATIVE1 = new BigNumber(-1);
@@ -80,7 +80,7 @@ class Utils
     /**
      * toHex
      * Encoding string or integer or numeric string(is not zero prefixed) or big number to hex.
-     * 
+     *
      * @param string|int|BigNumber $value
      * @param bool $isPrefix
      * @return string
@@ -108,7 +108,7 @@ class Utils
 
     /**
      * hexToBin
-     * 
+     *
      * @param string
      * @return string
      */
@@ -130,7 +130,7 @@ class Utils
 
     /**
      * isZeroPrefixed
-     * 
+     *
      * @param string
      * @return bool
      */
@@ -144,7 +144,7 @@ class Utils
 
     /**
      * stripZero
-     * 
+     *
      * @param string $value
      * @return string
      */
@@ -159,7 +159,7 @@ class Utils
 
     /**
      * isNegative
-     * 
+     *
      * @param string
      * @return bool
      */
@@ -173,7 +173,7 @@ class Utils
 
     /**
      * isAddress
-     * 
+     *
      * @param string $value
      * @return bool true if the address is lowercase or in checksum format otherwise false
      */
@@ -243,7 +243,7 @@ class Utils
 
     /**
      * isHex
-     * 
+     *
      * @param string $value
      * @return bool
      */
@@ -255,7 +255,7 @@ class Utils
     /**
      * sha3
      * keccak256
-     * 
+     *
      * @param string $value
      * @return string
      */
@@ -277,7 +277,7 @@ class Utils
 
     /**
      * toString
-     * 
+     *
      * @param mixed $value
      * @return string
      */
@@ -292,9 +292,9 @@ class Utils
      * toWei
      * Change number from unit to wei.
      * For example:
-     * $wei = Utils::toWei('1', 'kwei'); 
+     * $wei = Utils::toWei('1', 'kwei');
      * $wei->toString(); // 1000
-     * 
+     *
      * @param BigNumber|string $number
      * @param string $unit
      * @return \phpseclib\Math\BigInteger
@@ -358,9 +358,9 @@ class Utils
      * toEther
      * Change number from unit to ether.
      * For example:
-     * list($bnq, $bnr) = Utils::toEther('1', 'kether'); 
+     * list($bnq, $bnr) = Utils::toEther('1', 'kether');
      * $bnq->toString(); // 1000
-     * 
+     *
      * @param BigNumber|string|int $number
      * @param string $unit
      * @return array
@@ -380,9 +380,9 @@ class Utils
      * fromWei
      * Change number from wei to unit.
      * For example:
-     * list($bnq, $bnr) = Utils::fromWei('1000', 'kwei'); 
+     * list($bnq, $bnr) = Utils::fromWei('1000', 'kwei');
      * $bnq->toString(); // 1
-     * 
+     *
      * @param BigNumber|string|int $number
      * @param string $unit
      * @return \phpseclib\Math\BigInteger
@@ -404,7 +404,7 @@ class Utils
 
     /**
      * jsonMethodToString
-     * 
+     *
      * @param stdClass|array $json
      * @return string
      */
@@ -450,7 +450,7 @@ class Utils
 
     /**
      * jsonToArray
-     * 
+     *
      * @param stdClass|array $json
      * @return array
      */
@@ -486,7 +486,7 @@ class Utils
     /**
      * toBn
      * Change number or number string to bignumber.
-     * 
+     *
      * @param BigNumber|string|int $number
      * @return array|\phpseclib\Math\BigInteger
      */
@@ -552,7 +552,7 @@ class Utils
 
     /**
      * hexToNumber
-     * 
+     *
      * @param string $hexNumber
      * @return int
      */

--- a/test/unit/BigNumberFormatterTest.php
+++ b/test/unit/BigNumberFormatterTest.php
@@ -3,21 +3,21 @@
 namespace Test\Unit;
 
 use Test\TestCase;
-use phpseclib\Math\BigInteger as BigNumber;
+use phpseclib3\Math\BigInteger as BigNumber;
 use Web3\Formatters\BigNumberFormatter;
 
-class BigNumberFormatterTest extends TestCase
+class BigNumberFormatterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * formatter
-     * 
+     *
      * @var \Web3\Formatters\BigNumberFormatter
      */
     protected $formatter;
 
     /**
      * setUp
-     * 
+     *
      * @return void
      */
     public function setUp(): void
@@ -28,7 +28,7 @@ class BigNumberFormatterTest extends TestCase
 
     /**
      * testFormat
-     * 
+     *
      * @return void
      */
     public function testFormat()

--- a/test/unit/ContractTest.php
+++ b/test/unit/ContractTest.php
@@ -8,7 +8,7 @@ use Web3\Contract;
 use Web3\Utils;
 use Web3\Contracts\Ethabi;
 use Web3\Formatters\IntegerFormatter;
-use phpseclib\Math\BigInteger as BigNumber;
+use phpseclib3\Math\BigInteger as BigNumber;
 
 class ContractTest extends TestCase
 {

--- a/test/unit/EthApiTest.php
+++ b/test/unit/EthApiTest.php
@@ -5,7 +5,7 @@ namespace Test\Unit;
 use RuntimeException;
 use InvalidArgumentException;
 use Test\TestCase;
-use phpseclib\Math\BigInteger as BigNumber;
+use phpseclib3\Math\BigInteger as BigNumber;
 
 class EthApiTest extends TestCase
 {

--- a/test/unit/EthBatchTest.php
+++ b/test/unit/EthBatchTest.php
@@ -4,7 +4,7 @@ namespace Test\Unit;
 
 use RuntimeException;
 use Test\TestCase;
-use phpseclib\Math\BigInteger as BigNumber;
+use phpseclib3\Math\BigInteger as BigNumber;
 
 class EthBatchTest extends TestCase
 {

--- a/test/unit/NetApiTest.php
+++ b/test/unit/NetApiTest.php
@@ -5,7 +5,7 @@ namespace Test\Unit;
 use RuntimeException;
 use InvalidArgumentException;
 use Test\TestCase;
-use phpseclib\Math\BigInteger as BigNumber;
+use phpseclib3\Math\BigInteger as BigNumber;
 
 class NetApiTest extends TestCase
 {

--- a/test/unit/NetBatchTest.php
+++ b/test/unit/NetBatchTest.php
@@ -4,7 +4,7 @@ namespace Test\Unit;
 
 use RuntimeException;
 use Test\TestCase;
-use phpseclib\Math\BigInteger as BigNumber;
+use phpseclib3\Math\BigInteger as BigNumber;
 
 class NetBatchTest extends TestCase
 {

--- a/test/unit/UtilsTest.php
+++ b/test/unit/UtilsTest.php
@@ -5,7 +5,7 @@ namespace Test\Unit;
 use InvalidArgumentException;
 use stdClass;
 use Test\TestCase;
-use phpseclib\Math\BigInteger as BigNumber;
+use phpseclib3\Math\BigInteger as BigNumber;
 use Web3\Utils;
 use Web3\Contract;
 


### PR DESCRIPTION
Some other packages in my project required phpseclib 3, which conflicted with the web3.php package being limited to phpseclib 2.

Ideally, web3.php could be compatible with both version 2 and version 3 if you think that moving to version 3 could break other people's projects. But I am not good enough to propose a PR doing this.

HTH!